### PR TITLE
remove --fail-under from tox (covdefaults handles this)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands =
     coverage erase
     coverage run -m pytest {posargs:tests}
     python testing/fix_coverage.py
-    coverage report --fail-under 100
+    coverage report
 
 [testenv:py36]
 # Don't run coverage when our implementation is not used


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos